### PR TITLE
scripts: Improve docker desktop confirmation and add manual okay

### DIFF
--- a/scripts/start_warnet.sh
+++ b/scripts/start_warnet.sh
@@ -33,13 +33,33 @@ echo "TODO: remove me when attackathon/18 has been addressed!"
 git fetch carla > /dev/null 2>&1 || { echo "Failed to fetch carla"; exit 1; }
 git checkout carla/attackathon > /dev/null 2>&1 || { echo "Failed to checkout carla/attackathon"; exit 1; }
 
+# Check whether running docker desktop or minikube.
 docker_info=$(docker info)
-
 if grep -q "Operating System:.*Desktop" <<< "$docker_info"; then
-    echo "Starting warnet for docker desktop."
+    docker_desktop=true
+else
+    docker_desktop=false
+fi
+
+# Only ask this question once, otherwise it's annoying.
+if [ "$docker_desktop" = true ]; then
+    echo "Detected docker desktop running."
+else
+    echo "Detected minikube running."
+fi
+
+read -p "Is this correct (y/n): " confirm
+if [ "$confirm" != "y" ]; then
+    echo "Unable to detect kubernetes platform - please open an issue with the output of $ docker info"
+    exit 1
+fi
+
+# Check Docker info and start accordingly
+if [ "$docker_desktop" = true ]; then
+    echo "Starting warnet for Docker Desktop."
     just startd
 else
-    echo "Starting warnet for docker."
+    echo "Starting warnet for Docker."
     just start
 fi
 

--- a/scripts/start_warnet.sh
+++ b/scripts/start_warnet.sh
@@ -35,7 +35,7 @@ git checkout carla/attackathon > /dev/null 2>&1 || { echo "Failed to checkout ca
 
 docker_info=$(docker info)
 
-if grep -q "Context:.*desktop" <<< "$docker_info"; then
+if grep -q "Operating System:.*Desktop" <<< "$docker_info"; then
     echo "Starting warnet for docker desktop."
     just startd
 else

--- a/scripts/stop_warnet.sh
+++ b/scripts/stop_warnet.sh
@@ -15,7 +15,7 @@ git checkout main
 docker_info=$(docker info)
 
 # Setup depends on docker or docker desktop.
-if grep -q "Context:.*desktop" <<< "$docker_info"; then
+if grep -q "Operating System:.*Desktop" <<< "$docker_info"; then
     echo "Stopping warnet for docker desktop."
     just stopd
 else

--- a/setup/create_network.sh
+++ b/setup/create_network.sh
@@ -115,8 +115,6 @@ fi
 # will use our generated data.
 echo "Generating warnet file for network"
 cd warnet 
-python3 -m venv .venv > /dev/null 2>&1 
-source .venv/bin/activate > /dev/null 2>&1 
 pip install -e . > /dev/null 2>&1 
 
 # Run warnet in the background and capture pid for shutdown.


### PR DESCRIPTION
Updating some scripts with feedback from most gracious guinneapig @ellemouton:
* Docker info `Context` can't be relied on to detect docker desktop - us OS instead
* Add manual confirmation of docker desktop vs minikube just in case, because it can mess things up if you run the wrong one (sorry Elle 😅 )
* Remove virtual env so that `warcli` is available errywhere