### PR TITLE
fix: Added simln and circutbreaker to clone

### DIFF
--- a/scripts/start_warnet.sh
+++ b/scripts/start_warnet.sh
@@ -11,6 +11,16 @@ check_command() {
 check_command just
 check_command docker
 
+# Cloning simln
+if [ ! -d "sim-ln" ]; then
+    git clone https://github.com/bitcoin-dev-project/sim-ln.git
+fi
+
+# Cloning circuitbreaker
+if [ ! -d "circuitbreaker" ]; then
+    git clone https://github.com/lightningequipment/circuitbreaker.git 
+fi
+
 if [ ! -d "warnet" ]; then
     git clone https://github.com/bitcoin-dev-project/warnet
 fi


### PR DESCRIPTION
I tried running the start up scripts in the readme and I had some port issue, then I noticed that I needed circutbreaker and simln cloned from a doc at the bottom of the readme so I just created a quick check to see if those repos are cloned

let me know if this is incorrect, this seemed to fix it on my local machine which is a MacOS