### PR TITLE
Adds cargo template pointing to a custom version of tonic_lnd

### DIFF
--- a/templates/rustlang/Cargo.toml
+++ b/templates/rustlang/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "attack-ln"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tonic_lnd = { git = "https://github.com/sr-gi/tonic_lnd", branch="2024-04-attackathon-rpc", features=["lightningrpc", "routerrpc"], package="fedimint-tonic-lnd"}


### PR DESCRIPTION
We need the endorsement flag which is not included in the fedimint version of tonic_lnd