### PR TITLE
analysis: generate projected data and use for comparative revenue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*.csv
+data.csv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -167,10 +167,11 @@ Attacks will be assessed using the following measures:
 - When compared to the operation of the network _without_ a jamming 
   attack, how many honest htlcs were dropped as a result of the attack?
 
-A work-in-progress analysis script can be run from within the 
-attackathon repo using:
+A work-in-progress analysis script requires your network name and the 
+runtime in nanoseconds that was output by `run.sh`. It can be run from 
+within the attackathon repo:
 
-`python3 analysis/analyse_attack.py ln_10`
+`python3 analysis/analyse_attack.py ln_10 <runtime_ns>`
 
 ### HackNicePlz
 

--- a/README.md
+++ b/README.md
@@ -167,8 +167,10 @@ Attacks will be assessed using the following measures:
 - When compared to the operation of the network _without_ a jamming 
   attack, how many honest htlcs were dropped as a result of the attack?
 
-A work-in-progress analysis script can be run using:
-`python3 analysis/analyse_attack.py`
+A work-in-progress analysis script can be run from within the 
+attackathon repo using:
+
+`python3 analysis/analyse_attack.py ln_10`
 
 ### HackNicePlz
 

--- a/analysis/analyse_attack.py
+++ b/analysis/analyse_attack.py
@@ -1,4 +1,5 @@
 import subprocess
+import csv
 import attacker_cost
 import tempfile
 import os
@@ -36,11 +37,45 @@ def save_channel_list(node_id):
         execute_command_and_save_output(command, temp_filename)
         return temp_filename
 
+def get_projected_revenue(network_name, node_id, revenue_period_ns):
+    file_path = os.path.join("data", network_name, "projected.csv")
+    total_fees = 0
+    timestamp_limit = None
+
+    with open(file_path, 'r') as file:
+        reader = csv.DictReader(file)
+        for row in reader:
+            incoming_amt = int(row['incoming_amt'])
+            outgoing_amt = int(row['outgoing_amt'])
+            forwarding_alias = row['forwarding_alias']
+            incoming_add_ts = int(row['incoming_add_ts'])
+            incoming_remove_ts = int(row['incoming_remove_ts'])
+           
+            # We want to only get entries for the period that we've defined to have a way to compare revenue to what we got in the simulation 
+            # that ran for revenue_period_ns. We don't have a start time for this projected data, so we just grab our first timestamp as the 
+            # start. This is imperfect, and may lead to us over-estimating revenue without an attack (especially if there was a long wait 
+            # for the first payment to occur). This could possibly be improved by including the start time in the file name so we can get 
+            # an exact start, but is okay for now.
+            # 
+            # We can't use actual timestamps here, because this data was generated once-off and has old timestamps (hasn't been "progressed"
+            # to current times like we do for bootstrapped data, as this isn't actually necessary).
+            if timestamp_limit is None:
+                timestamp_limit = incoming_add_ts + revenue_period_ns
+
+            if incoming_add_ts >= timestamp_limit:
+                break
+            
+            if forwarding_alias == node_id and incoming_remove_ts < timestamp_limit:
+                total_fees += (incoming_amt - outgoing_amt)
+    
+    return total_fees
+
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: python analyse_attack.py <network_name>")
+    if len(sys.argv) != 3:
+        print("Usage: python analyse_attack.py <network_name> <attack_runtime_ns>")
         sys.exit(1)
     network_name = sys.argv[1]
+    runtime_ns = int(sys.argv[2])
     
     # Construct the file path
     file_path = os.path.join("data", network_name, "target.txt")
@@ -79,3 +114,6 @@ if __name__ == "__main__":
     print()
     revenue = attacker_cost.get_revenue(node_id)
     print(f"Target revenue under attack: {revenue} msat")
+
+    projected = get_projected_revenue(network_name, node_id, runtime_ns)
+    print(f"Target revenue without attack: {projected} msat")

--- a/analysis/analyse_attack.py
+++ b/analysis/analyse_attack.py
@@ -1,6 +1,7 @@
 import subprocess
 import attacker_cost
 import tempfile
+import os
 import sys
 import target_jammed
 
@@ -37,9 +38,20 @@ def save_channel_list(node_id):
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: python script.py <node_id>")
+        print("Usage: python analyse_attack.py <network_name>")
         sys.exit(1)
-    node_id = sys.argv[1]
+    network_name = sys.argv[1]
+    
+    # Construct the file path
+    file_path = os.path.join("data", network_name, "target.txt")
+
+    if os.path.exists(file_path):
+        with open(file_path, 'r') as file:
+            node_id = file.read().strip()
+            print(f"Running attack analysis for target node: {node_id}")
+    else:
+        print(f"The network at {file_path} does not exist.")
+        sys.exit(1)
 
     padded_node_id = node_id.zfill(6)   
     forwarding_hist_file = save_forwarding_history(padded_node_id)

--- a/setup/create_network.sh
+++ b/setup/create_network.sh
@@ -80,11 +80,48 @@ else
     git remote remove carla
     git checkout main > /dev/null 2>&1
 
-    runtime=$((duration / 1000))
-    echo "Generating historical data for $duration seconds, will take: $runtime seconds with speedup of 1000"
-    sim-cli --clock-speedup 1000 -s "$simfile" -t "$duration"
-	
-    cp results/htlc_forwards.csv "$raw_data"
+    # We want to generate two types of data here (TODO: fix seed):
+    # 1. Bootstrapping data for the network, which provides historical reputations
+    # 2. Projected revenue, which provides simulated network traffic without an attack present
+    # Everything before ts_division is (1) and everything after is (2)
+    sim_time=$(( duration + 14 * 24 * 60 * 60 ))
+    ts_division=$(( ($(date +%s) + duration) * 1000000000 ))
+
+    runtime=$((sim_time / 1000))
+    echo "Generating historical and projected data for $sim_time seconds, will take: $runtime seconds with speedup of 1000"
+    sim-cli --clock-speedup 1000 -s "$simfile" -t "$sim_time"
+
+    # Once data is generated, we'll split it between historical bootstrap and projected revenue.
+    input_csv="results/htlc_forwards.csv"
+
+    # Filenames for output CSVs
+    file_lt_division="historical_data.csv"
+    file_ge_division="projected_forwards.csv"
+
+    # Header for the output CSVs
+    header=$(head -n 1 "$input_csv")
+
+    # Creating new CSV files with headers
+    echo "$header" > "$file_lt_division"
+    echo "$header" > "$file_ge_division"
+
+    # Processing each line in the input CSV, starting from the second line (skipping header)
+    tail -n +2 "$input_csv" | while IFS=',' read -r incoming_amt incoming_expiry incoming_add_ts incoming_remove_ts \
+                                    outgoing_amt outgoing_expiry outgoing_add_ts outgoing_remove_ts \
+                                    forwarding_node forwarding_alias chan_in chan_out; do
+    # Determine which file to write to based on condition
+    if [ "$outgoing_remove_ts" -lt "$ts_division" ]; then
+        echo "$incoming_amt,$incoming_expiry,$incoming_add_ts,$incoming_remove_ts,$outgoing_amt,$outgoing_expiry,$outgoing_add_ts,$outgoing_remove_ts,$forwarding_node,$forwarding_alias,$chan_in,$chan_out" >> "$file_lt_division"
+    else
+        echo "$incoming_amt,$incoming_expiry,$incoming_add_ts,$incoming_remove_ts,$outgoing_amt,$outgoing_expiry,$outgoing_add_ts,$outgoing_remove_ts,$forwarding_node,$forwarding_alias,$chan_in,$chan_out" >> "$file_ge_division"
+    fi
+    done
+
+    # Copy bootstraped data into place for raw data to build circuitbreaker data.
+    mv "$file_lt_division" "$raw_data"
+
+    # Copy remaining data into folder for simulation so that analysis can use projected data for comparisons.
+    mv "$file_ge_division" "$sim_files/projected.csv"
     cd ..
 fi
 

--- a/setup/run.sh
+++ b/setup/run.sh
@@ -22,7 +22,15 @@ export LND_2_MACAROON="/credentials/lnd2-admin.macaroon"
 
 export TARGET=$(cat target.txt)
 
+start_time_s=$(date +%s)
+echo "Starting attack at: $start_time_s!"
+
 # Fill in code here to:
 # - Clone your repo
 # - Install your program
 # - Run it with the certs/macaroons provided above
+
+# Do not delete this!
+end_time_s=$(date +%s)
+runtime=$(( ($end_time_s - $start_time_s) * 1000000000 ))
+echo "Attack duration: $runtime ns"


### PR DESCRIPTION
Use simulator that we're already using for bootstrapped history to generate two weeks of projected revenue without attack being executed against the network. For this to be useful, we need to fix the seed for sim-ln in both the projections and the warnet network so that the same payments are executed on both. This is TBD waiting on https://github.com/bitcoin-dev-project/sim-ln/pull/178. 